### PR TITLE
Use `libc::mmap` directly again, instead of `mmap-alloc` crate

### DIFF
--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -32,11 +32,6 @@ unreachable = "1.0.0"
 default-features = false
 version = "0.2"
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies.mmap-alloc]
-version = "0.2"
-git = "https://github.com/fitzgen/allocators-rs"
-branch = "new-alloc-api"
-
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3"
 features = ["memoryapi", "synchapi", "winbase"]

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -237,7 +237,6 @@ cfg_if! {
         use imp_wasm32 as imp;
     } else if #[cfg(unix)] {
         extern crate libc;
-        extern crate mmap_alloc;
         mod imp_unix;
         use imp_unix as imp;
     } else if #[cfg(windows)] {

--- a/wee_alloc/src/neighbors.rs
+++ b/wee_alloc/src/neighbors.rs
@@ -59,6 +59,7 @@ where
 
     #[test]
     fn can_use_low_bits() {
+        use core::mem;
         assert!(
             mem::align_of::<*const u8>() >= 0b100,
             "we rely on being able to stick tags into the lowest two bits"


### PR DESCRIPTION
Revert "Use mmap-alloc crate for mmap allocations"

This reverts commit 195bd59ba3f30d34e2ec9238a3a64d4ce6956331.

The mmap-alloc crate doesn't support the new allocators interface, and won't for a while. Easiest thing is to just go back to raw `mmap` calls.