### PR TITLE
Fixed-sized backend for use with atypical targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,9 +141,9 @@ Where we need help:
 
 ## Team
 
-| [<img alt="fitzgen" src="https://avatars2.githubusercontent.com/u/74571?s=117&v=4" width="117">](https://github.com/fitzgen) | [<img alt="pepyakin" src="https://avatars0.githubusercontent.com/u/2205845?s=117&v=4" width="117">](https://github.com/pepyakin) | [<img alt="DrGoldfire" src="https://avatars3.githubusercontent.com/u/1772277?s=117&v=4" width="117">](https://github.com/DrGoldfire) |
-|:---:|:---:|:---:|
-| [`fitzgen`](https://github.com/fitzgen) | [`pepyakin`](https://github.com/pepyakin) | [`DrGoldfire`](https://github.com/DrGoldfire) |
+| [<img alt="fitzgen" src="https://avatars2.githubusercontent.com/u/74571?s=117&v=4" width="117">](https://github.com/fitzgen) | [<img alt="pepyakin" src="https://avatars0.githubusercontent.com/u/2205845?s=117&v=4" width="117">](https://github.com/pepyakin) | [<img alt="DrGoldfire" src="https://avatars3.githubusercontent.com/u/1772277?s=117&v=4" width="117">](https://github.com/DrGoldfire) | [<img alt="ZackPierce" src="https://avatars0.githubusercontent.com/u/387703?s=400&v=4" width="117">](https://github.com/ZackPierce) |
+|:---:|:---:|:---:|:---:|
+| [`fitzgen`](https://github.com/fitzgen) | [`pepyakin`](https://github.com/pepyakin) | [`DrGoldfire`](https://github.com/DrGoldfire) | [`ZackPierce`](https://github.com/ZackPierce)
 
 Larger, more nuanced decisions about design, architecture, breaking changes,
 trade offs, etc are made by team consensus. In other words, decisions on things

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
   runtime overhead. It is useful when debugging a use-after-free or `wee_alloc`
   itself.
 
+- **static_array_backend**: Force the use of an OS-independent fixed-size (16 MB)
+  backing implementation. Suitable for deploying to non-WASM/Unix/Windows
+  `#![no_std]` environments, such as on embedded devices with esoteric or effectively
+  absent operating systems.
+
 ### Implementation Notes and Constraints
 
 - `wee_alloc` imposes two words of overhead on each allocation for maintaining

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -25,6 +25,15 @@ extern "C" fn panic_fmt(_args: ::core::fmt::Arguments, _file: &'static str, _lin
     }
 }
 
+// Need to provide a tiny `oom` lang-item implementation for
+// `#![no_std]`.
+#[lang = "oom"]
+extern "C" fn oom() -> ! {
+    unsafe {
+        ::core::intrinsics::abort();
+    }
+}
+
 // Now, use the allocator via `alloc` types! ///////////////////////////////////
 
 use alloc::boxed::Box;

--- a/test.sh
+++ b/test.sh
@@ -15,4 +15,9 @@ time cargo test --release --features "extra_assertions size_classes"
 time cargo test --release --features "extra_assertions"
 time cargo test --release --features "size_classes"
 time cargo test --release
+
+time cargo test --release --features "static_array_backend extra_assertions size_classes"
+time cargo test --release --features "static_array_backend extra_assertions"
+time cargo test --release --features "static_array_backend size_classes"
+time cargo test --release --features "static_array_backend"
 cd -

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 rand = "0.4.2"
 quickcheck = "0.6.0"
 histo = "0.1.0"
+cfg-if = "0.1.2"
 
 [dependencies.wee_alloc]
 path = "../wee_alloc"
@@ -16,3 +17,4 @@ features = ["use_std_for_test_debugging"]
 [features]
 size_classes = ["wee_alloc/size_classes"]
 extra_assertions = ["wee_alloc/extra_assertions"]
+static_array_backend = ["wee_alloc/static_array_backend"]

--- a/test/benches/bench.rs
+++ b/test/benches/bench.rs
@@ -8,7 +8,7 @@ use std::io;
 use wee_alloc_test::*;
 
 macro_rules! bench_trace {
-    ( $name:ident, $trace:expr ) => {
+    ($name:ident, $trace:expr) => {
         #[bench]
         #[cfg(not(feature = "extra_assertions"))]
         fn $name(b: &mut test::Bencher) {
@@ -18,7 +18,10 @@ macro_rules! bench_trace {
                 let stdout = io::stdout();
                 let _stdout = stdout.lock();
 
-                println!("################## {} ##################", stringify!($name));
+                println!(
+                    "################## {} ##################",
+                    stringify!($name)
+                );
                 println!("#");
                 println!("# Allocations by log2(Size)");
                 println!("#");
@@ -34,7 +37,7 @@ macro_rules! bench_trace {
                 operations.run_with_allocator(a);
             });
         }
-    }
+    };
 }
 
 bench_trace!(bench_trace_cpp_demangle, "../traces/cpp-demangle.trace");
@@ -42,7 +45,10 @@ bench_trace!(bench_trace_dogfood, "../traces/dogfood.trace");
 bench_trace!(bench_trace_ffmpeg, "../traces/ffmpeg.trace");
 bench_trace!(bench_trace_find, "../traces/find.trace");
 bench_trace!(bench_trace_gcc_hello, "../traces/gcc-hello.trace");
-bench_trace!(bench_trace_grep_random_data, "../traces/grep-random-data.trace");
+bench_trace!(
+    bench_trace_grep_random_data,
+    "../traces/grep-random-data.trace"
+);
 bench_trace!(bench_trace_grep_recursive, "../traces/grep-recursive.trace");
 bench_trace!(bench_trace_ls, "../traces/ls.trace");
 bench_trace!(bench_trace_source_map, "../traces/source-map.trace");

--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -1,5 +1,10 @@
 [package]
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+authors = [
+  "Nick Fitzgerald <fitzgen@gmail.com>",
+  "Sergey Pepyakin <s.pepyakin@gmail.com>",
+  "Matt Howell <mjhowell@gmail.com>",
+  "Zack Pierce <zachary.pierce@gmail.com>",
+]
 categories = ["memory-management", "web-programming", "no-std", "wasm", "embedded"]
 description = "wee_alloc: The Wasm-Enabled, Elfin Allocator"
 license = "MPL-2.0"

--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -23,10 +23,17 @@ size_classes = []
 # This is for internal use only.
 use_std_for_test_debugging = []
 
+static_array_backend = []
+
 [dependencies]
 memory_units = "0.4.0"
 cfg-if = "0.1.2"
 unreachable = "1.0.0"
+
+[dependencies.spin]
+version = "0.4"
+default-features = false
+features = ["const_fn"]
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies.libc]
 default-features = false

--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
-categories = ["memory-management", "web-programming", "no-std", "wasm"]
+categories = ["memory-management", "web-programming", "no-std", "wasm", "embedded"]
 description = "wee_alloc: The Wasm-Enabled, Elfin Allocator"
 license = "MPL-2.0"
 name = "wee_alloc"
@@ -20,10 +20,11 @@ extra_assertions = []
 # Enable size classes for amortized *O(1)* small allocations.
 size_classes = []
 
+# Enable fixed-sized, OS-independent backing memory implementation
+static_array_backend = []
+
 # This is for internal use only.
 use_std_for_test_debugging = []
-
-static_array_backend = []
 
 [dependencies]
 memory_units = "0.4.0"

--- a/wee_alloc/src/imp_static_array.rs
+++ b/wee_alloc/src/imp_static_array.rs
@@ -1,0 +1,86 @@
+use const_init::ConstInit;
+use core::alloc::{AllocErr, Opaque};
+use core::cell::UnsafeCell;
+#[cfg(feature = "extra_assertions")]
+use core::cell::Cell;
+use core::ptr::NonNull;
+use memory_units::{Bytes, Pages};
+use spin::Mutex;
+
+const SCRATCH_LEN_BYTES: usize = 1024 * 1024 * 32;
+static mut SCRATCH_HEAP: [u8; SCRATCH_LEN_BYTES] = [0; SCRATCH_LEN_BYTES];
+static mut OFFSET: Mutex<usize> = Mutex::new(0);
+
+pub(crate) unsafe fn alloc_pages(pages: Pages) -> Result<NonNull<Opaque>, AllocErr> {
+    let bytes: Bytes = pages.into();
+    let mut offset = OFFSET.lock();
+    let end = bytes.0 + *offset;
+    if end < SCRATCH_LEN_BYTES {
+        let ptr = SCRATCH_HEAP[*offset..end].as_mut_ptr() as *mut u8 as *mut Opaque;
+        *offset = end;
+        NonNull::new(ptr).ok_or_else(|| AllocErr)
+    } else {
+        Err(AllocErr)
+    }
+}
+
+pub(crate) struct Exclusive<T> {
+    lock: Mutex<bool>,
+    inner: UnsafeCell<T>,
+
+    #[cfg(feature = "extra_assertions")]
+    in_use: Cell<bool>,
+}
+
+impl<T: ConstInit> ConstInit for Exclusive<T> {
+    const INIT: Self = Exclusive {
+        lock: Mutex::new(false),
+        inner: UnsafeCell::new(T::INIT),
+
+        #[cfg(feature = "extra_assertions")]
+        in_use: Cell::new(false),
+    };
+}
+
+extra_only! {
+    fn assert_not_in_use<T>(excl: &Exclusive<T>) {
+        assert!(!excl.in_use.get(), "`Exclusive<T>` is not re-entrant");
+    }
+}
+
+extra_only! {
+    fn set_in_use<T>(excl: &Exclusive<T>) {
+        excl.in_use.set(true);
+    }
+}
+
+extra_only! {
+    fn set_not_in_use<T>(excl: &Exclusive<T>) {
+        excl.in_use.set(false);
+    }
+}
+
+impl<T> Exclusive<T> {
+    /// Get exclusive, mutable access to the inner value.
+    ///
+    /// # Safety
+    ///
+    /// It is the callers' responsibility to ensure that `f` does not re-enter
+    /// this method for this `Exclusive` instance.
+    //
+    // XXX: If we don't mark this function inline, then it won't be, and the
+    // code size also blows up by about 200 bytes.
+    #[inline]
+    pub(crate) unsafe fn with_exclusive_access<'a, F, U>(&'a self, f: F) -> U
+    where
+        F: FnOnce(&'a mut T) -> U,
+    {
+        let _l = self.lock.lock();
+        assert_not_in_use(self);
+        set_in_use(self);
+        let data = &mut *self.inner.get();
+        let result = f(data);
+        set_not_in_use(self);
+        result
+    }
+}

--- a/wee_alloc/src/imp_unix.rs
+++ b/wee_alloc/src/imp_unix.rs
@@ -50,7 +50,7 @@ impl<T> Exclusive<T> {
     #[inline]
     pub(crate) unsafe fn with_exclusive_access<'a, F, U>(&'a self, f: F) -> U
     where
-        F: FnOnce(&'a mut T) -> U,
+        for<'x> F: FnOnce(&'x mut T) -> U,
     {
         let code = libc::pthread_mutex_lock(&mut *self.lock.get());
         extra_assert_eq!(code, 0, "pthread_mutex_lock should run OK");

--- a/wee_alloc/src/imp_wasm32.rs
+++ b/wee_alloc/src/imp_wasm32.rs
@@ -68,7 +68,7 @@ impl<T> Exclusive<T> {
     #[inline]
     pub(crate) unsafe fn with_exclusive_access<'a, F, U>(&'a self, f: F) -> U
     where
-        F: FnOnce(&'a mut T) -> U,
+        for<'x> F: FnOnce(&'x mut T) -> U,
     {
         assert_not_in_use(self);
         set_in_use(self);

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -110,6 +110,11 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
   runtime overhead. It is useful when debugging a use-after-free or `wee_alloc`
   itself.
 
+- **static_array_backend**: Force the use of an OS-independent fixed-size (16 MB)
+  backing implementation. Suitable for deploying to non-WASM/Unix/Windows
+  `#![no_std]` environments, such as on embedded devices with esoteric or effectively
+  absent operating systems.
+
 ## Implementation Notes and Constraints
 
 - `wee_alloc` imposes two words of overhead on each allocation for maintaining

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -239,7 +239,7 @@ extern crate unreachable;
 mod extra_assert;
 
 cfg_if! {
-    if #[cfg(feature = "static_array_backend")]{
+    if #[cfg(feature = "static_array_backend")] {
         mod imp_static_array;
         use imp_static_array as imp;
     } else if #[cfg(target_arch = "wasm32")] {

--- a/wee_alloc/src/neighbors.rs
+++ b/wee_alloc/src/neighbors.rs
@@ -185,16 +185,12 @@ where
 
     #[inline]
     pub fn next(&self) -> Option<&'a T> {
-        unsafe {
-            T::next_checked(self, self.next_unchecked())
-        }
+        unsafe { T::next_checked(self, self.next_unchecked()) }
     }
 
     #[inline]
     pub fn prev(&self) -> Option<&'a T> {
-        unsafe {
-            T::prev_checked(self, self.prev_unchecked())
-        }
+        unsafe { T::prev_checked(self, self.prev_unchecked()) }
     }
 }
 

--- a/wee_alloc/src/size_classes.rs
+++ b/wee_alloc/src/size_classes.rs
@@ -1,6 +1,6 @@
 use super::{alloc_with_refill, AllocPolicy, CellHeader, FreeCell, LargeAllocPolicy};
-use core::alloc::AllocErr;
 use const_init::ConstInit;
+use core::alloc::AllocErr;
 use core::cell::Cell;
 use core::cmp;
 use imp;
@@ -75,7 +75,10 @@ where
             self as &AllocPolicy,
         );
         let next_cell = (new_cell.as_ptr() as *const u8).offset(new_cell_size.0 as isize);
-        (*free_cell).header.neighbors.set_next(next_cell as *const CellHeader);
+        (*free_cell)
+            .header
+            .neighbors
+            .set_next(next_cell as *const CellHeader);
         CellHeader::set_next_cell_is_invalid(&(*free_cell).header.neighbors);
         Ok(free_cell)
     }


### PR DESCRIPTION
Hello, `wee_alloc` team! @fitzgen @pepyakin @DrGoldfire 

## Summary

This PR expands the usability of `wee_alloc` for arbitrary `#[no_std]` targets with a bit of memory lying around.

## What

The main change is the introduction of a `static_array_backend` feature that causes `wee_alloc` to use an implementation that works largely independent of the operating environment capabilities, at the cost of having a completely fixed maximum size, currently 32 megabytes.

This feature is entirely conditionally compiled, and *not* present by default, and thus should have no noteworthy burden on extant code capabilities or size.

Per the CONTRIBUTING guidelines, `cargo fmt --all` was run on this branch, which caused some nonessential changes to unrelated files.

## Why

This contribution rose out of my desire to apply `wee_alloc`, a well-tested and actively developed allocator in the context of a non-Unix/WASM/Windows environment. 

I hope that an OS-independent option will also provide other developers a quick way to get `wee_alloc` up and running for use cases associated with less common operating systems or environments.


## Future Directions

I could imagine further refinement by using either feature flags, tricky macros, or generics to allow control of the size of the presently-fixed static array backend. Said refinements have been intentionally excluded from this PR in order to keep the complexity down and, more importantly, avoid any impact on the primary use cases. If there is interest, we could expand the backend flexibility in future efforts.