### PR TITLE
Add compile-time env var sizing of `static_array_backend`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target/
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -110,10 +110,13 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
   runtime overhead. It is useful when debugging a use-after-free or `wee_alloc`
   itself.
 
-- **static_array_backend**: Force the use of an OS-independent fixed-size (16 MB)
-  backing implementation. Suitable for deploying to non-WASM/Unix/Windows
-  `#![no_std]` environments, such as on embedded devices with esoteric or effectively
-  absent operating systems.
+- **static_array_backend**: Force the use of an OS-independent backing
+  implementation with a global maximum size fixed at compile time.
+  Suitable for deploying to non-WASM/Unix/Windows `#![no_std]` environments,
+  such as on embedded devices with esoteric or effectively absent operating
+  systems. The size defaults to 32 MB (33554432 bytes), and may be controlled
+  at build-time by supplying an optional environment variable to cargo,
+  `WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES`
 
 ### Implementation Notes and Constraints
 

--- a/check.sh
+++ b/check.sh
@@ -11,6 +11,8 @@ cargo check                         --target i686-pc-windows-gnu
 cargo check --features size_classes
 cargo check --features size_classes --target wasm32-unknown-unknown
 cargo check --features size_classes --target i686-pc-windows-gnu
+cargo check --no-default-features --features "static_array_backend"
+cargo check --no-default-features --features "static_array_backend size_classes"
 cd -
 
 cd ./test

--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -26,7 +26,7 @@ extra_assertions = []
 size_classes = []
 
 # Enable fixed-sized, OS-independent backing memory implementation
-static_array_backend = []
+static_array_backend = ["spin"]
 
 # This is for internal use only.
 use_std_for_test_debugging = []
@@ -38,6 +38,7 @@ unreachable = "1.0.0"
 
 [dependencies.spin]
 version = "0.4"
+optional = true
 default-features = false
 features = ["const_fn"]
 
@@ -48,3 +49,6 @@ version = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3"
 features = ["memoryapi", "synchapi", "winbase"]
+
+[build-dependencies]
+globwalk = "0.3"

--- a/wee_alloc/build.rs
+++ b/wee_alloc/build.rs
@@ -1,0 +1,45 @@
+extern crate globwalk;
+
+use std::env::{self, VarError};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+const DEFAULT_STATIC_ARRAY_BACKEND_SIZE_BYTES: u32 = 1024 * 1024 * 32;
+const WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES: &'static str = "WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES";
+
+fn main() {
+    create_static_array_backend_size_bytes_file();
+    export_rerun_rules();
+}
+
+fn create_static_array_backend_size_bytes_file() {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR environment variable not provided");
+    let dest_path = Path::new(&out_dir).join("wee_alloc_static_array_backend_size_bytes.txt");
+    let size: u32 = match env::var(WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES) {
+        Ok(s) => s.parse().expect("Could not interpret WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES as a 32 bit unsigned integer"),
+        Err(ve) => match ve {
+            VarError::NotPresent => { DEFAULT_STATIC_ARRAY_BACKEND_SIZE_BYTES },
+            VarError::NotUnicode(_) => { panic!("Could not interpret WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES as a string representing a 32 bit unsigned integer")},
+        },
+    };
+    println!("Setting the static_array_backend size to {} bytes", size);
+    let mut f = File::create(&dest_path)
+        .expect("Could not create file to store wee_alloc static_array_backend size metadata.");
+    write!(f, "{}", size)
+        .expect("Could not write to wee_alloc static_array_backend size metadata file");
+    f.flush()
+        .expect("Could not flush write to wee_alloc static_array_backend size metadata file");
+}
+fn export_rerun_rules() {
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES
+    );
+    for entry_result in
+        globwalk::glob("*.{toml,rs}").expect("Could not create a valid rust-file-finding glob")
+    {
+        let file = entry_result.expect("Failed to read file information.");
+        println!("cargo:rerun-if-changed={}", file.path().display());
+    }
+}

--- a/wee_alloc/src/imp_static_array.rs
+++ b/wee_alloc/src/imp_static_array.rs
@@ -6,7 +6,7 @@ use core::ptr::NonNull;
 use memory_units::{Bytes, Pages};
 use spin::Mutex;
 
-const SCRATCH_LEN_BYTES: usize = 1024 * 1024 * 32;
+const SCRATCH_LEN_BYTES: usize = include!(concat!(env!("OUT_DIR"), "/wee_alloc_static_array_backend_size_bytes.txt"));
 static mut SCRATCH_HEAP: [u8; SCRATCH_LEN_BYTES] = [0; SCRATCH_LEN_BYTES];
 static mut OFFSET: Mutex<usize> = Mutex::new(0);
 

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -110,10 +110,13 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
   runtime overhead. It is useful when debugging a use-after-free or `wee_alloc`
   itself.
 
-- **static_array_backend**: Force the use of an OS-independent fixed-size (16 MB)
-  backing implementation. Suitable for deploying to non-WASM/Unix/Windows
-  `#![no_std]` environments, such as on embedded devices with esoteric or effectively
-  absent operating systems.
+- **static_array_backend**: Force the use of an OS-independent backing
+  implementation with a global maximum size fixed at compile time.
+  Suitable for deploying to non-WASM/Unix/Windows `#![no_std]` environments,
+  such as on embedded devices with esoteric or effectively absent operating
+  systems. The size defaults to 32 MB (33554432 bytes), and may be controlled
+  at build-time by supplying an optional environment variable to cargo,
+  `WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES`
 
 ## Implementation Notes and Constraints
 


### PR DESCRIPTION
## Summary

Allow the `static_array_backend` to be optionally sized at compile time by the end user

## What

A build script has been added to `wee_alloc` that reads the `WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES` environment variable, does some sanitization to be sure it fits in `u32`, and records the numeric value as UTF8 in a "wee_alloc_static_array_backend_size_bytes.txt" file in the build output directory. This file is directly included in `wee_alloc/src/imp_static_array.rs` as the value for `SCRATCH_LEN_BYTES`.

This environment variable usage is entirely optional. The default remains the same, at 32 megabytes.

## Why

To allow users with direct knowledge of the memory available on their systems to better fit their use of the `static_array_backend` feature to the resources at hand.