### PR TITLE
Fix macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 // This translates into an `unreachable` instruction that will
 // raise a `trap` the WebAssembly execution if we panic at runtime.
 #[panic_implementation]
-fn panic(_info: &::core::panic::PanicInfo) -> ! {
+#[no_mangle]
+pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
     unsafe {
         ::core::intrinsics::abort();
     }
@@ -74,7 +75,8 @@ fn panic(_info: &::core::panic::PanicInfo) -> ! {
 // Need to provide a tiny `oom` lang-item implementation for
 // `#![no_std]`.
 #[lang = "oom"]
-extern "C" fn oom() -> ! {
+#[no_mangle]
+pub extern "C" fn oom() -> ! {
     unsafe {
         ::core::intrinsics::abort();
     }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -19,7 +19,8 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 // This translates into an `unreachable` instruction that will
 // raise a `trap` the WebAssembly execution if we panic at runtime.
 #[panic_implementation]
-fn panic(_info: &::core::panic::PanicInfo) -> ! {
+#[no_mangle]
+pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
     unsafe {
         ::core::intrinsics::abort();
     }
@@ -28,7 +29,8 @@ fn panic(_info: &::core::panic::PanicInfo) -> ! {
 // Need to provide a tiny `oom` lang-item implementation for
 // `#![no_std]`.
 #[lang = "oom"]
-extern "C" fn oom() -> ! {
+#[no_mangle]
+pub extern "C" fn oom() -> ! {
     unsafe {
         ::core::intrinsics::abort();
     }
@@ -36,6 +38,7 @@ extern "C" fn oom() -> ! {
 
 // Needed for non-wasm targets.
 #[lang = "eh_personality"]
+#[no_mangle]
 pub extern "C" fn eh_personality() {}
 
 // Now, use the allocator via `alloc` types! ///////////////////////////////////

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -65,7 +65,8 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 // This translates into an `unreachable` instruction that will
 // raise a `trap` the WebAssembly execution if we panic at runtime.
 #[panic_implementation]
-fn panic(_info: &::core::panic::PanicInfo) -> ! {
+#[no_mangle]
+pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
     unsafe {
         ::core::intrinsics::abort();
     }
@@ -74,7 +75,8 @@ fn panic(_info: &::core::panic::PanicInfo) -> ! {
 // Need to provide a tiny `oom` lang-item implementation for
 // `#![no_std]`.
 #[lang = "oom"]
-extern "C" fn oom() -> ! {
+#[no_mangle]
+pub extern "C" fn oom() -> ! {
     unsafe {
         ::core::intrinsics::abort();
     }


### PR DESCRIPTION
Add a bunch of `#[no_mangle]` attributes.

Without them build on my macOS fails with the following message:

```
Undefined symbols for architecture x86_64:
            "_rust_begin_unwind", referenced from:
                core::panicking::panic_fmt::heccabe37567c28da in libcore-7e253e08f02977a1.rlib(core-7e253e08f02977a1.core10-235e18517a5d1f9d344d37efda7c0ae3.rs.rcgu.o)
            "_rust_eh_personality", referenced from:
                Dwarf Exception Unwind Info (__eh_frame) in libwee_alloc-2ffc904d123a5710.rlib(wee_alloc-2ffc904d123a5710.1s8rvm7wrqdkd8at.rcgu.o)
                Dwarf Exception Unwind Info (__eh_frame) in libwee_alloc-2ffc904d123a5710.rlib(wee_alloc-2ffc904d123a5710.45pc7c65foh9i35f.rcgu.o)
                Dwarf Exception Unwind Info (__eh_frame) in libwee_alloc-2ffc904d123a5710.rlib(wee_alloc-2ffc904d123a5710.4ypvbwho0bu5tnww.rcgu.o)
                Dwarf Exception Unwind Info (__eh_frame) in libwee_alloc-2ffc904d123a5710.rlib(wee_alloc-2ffc904d123a5710.4yh8x2b62dcih00t.rcgu.o)
                Dwarf Exception Unwind Info (__eh_frame) in libwee_alloc-2ffc904d123a5710.rlib(wee_alloc-2ffc904d123a5710.4bt0r9a603dyx07q.rcgu.o)
                Dwarf Exception Unwind Info (__eh_frame) in libwee_alloc-2ffc904d123a5710.rlib(wee_alloc-2ffc904d123a5710.2a1u3y805arbp2ci.rcgu.o)
            "_rust_oom", referenced from:
                alloc::alloc::oom::h99a89b7c3fef7777 in liballoc-5a57e696ee9e9c78.rlib(alloc-5a57e696ee9e9c78.alloc15-7177bc392b2bbbe3920a4bea3511568b.rs.rcgu.o)
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```