### PR TITLE
Avoid LLVM intrinsics in favor of `core::arch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# `wee_alloc`
+[![Build Status](https://travis-ci.org/rustwasm/wee_alloc.svg?branch=master)](https://travis-ci.org/rustwasm/wee_alloc)
+
+# wee_alloc
 
 
 [![](https://docs.rs/wee_alloc/badge.svg)](https://docs.rs/wee_alloc/)
@@ -222,3 +224,5 @@ See
 [CONTRIBUTING.md](https://github.com/rustwasm/wee_alloc/blob/master/CONTRIBUTING.md)
 for hacking!
 
+
+License: MPL-2.0

--- a/wee_alloc/src/imp_wasm32.rs
+++ b/wee_alloc/src/imp_wasm32.rs
@@ -1,17 +1,13 @@
 use super::{assert_is_word_aligned, PAGE_SIZE, unchecked_unwrap};
 use const_init::ConstInit;
 use core::alloc::AllocErr;
+use core::arch::wasm32;
 use core::cell::UnsafeCell;
 use core::ptr::NonNull;
 use memory_units::Pages;
 
-extern "C" {
-    #[link_name = "llvm.wasm.grow.memory.i32"]
-    fn grow_memory(pages: usize) -> i32;
-}
-
 pub(crate) unsafe fn alloc_pages(n: Pages) -> Result<NonNull<u8>, AllocErr> {
-    let ptr = grow_memory(n.0);
+    let ptr = wasm32::grow_memory(n.0 as i32);
     if -1 != ptr {
         let ptr = (ptr as usize * PAGE_SIZE.0) as *mut u8;
         assert_is_word_aligned(ptr as *mut u8);

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -226,7 +226,7 @@ for hacking!
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "use_std_for_test_debugging"), no_std)]
 #![feature(alloc, allocator_api, core_intrinsics)]
-#![cfg_attr(target_arch = "wasm32", feature(link_llvm_intrinsics))]
+#![cfg_attr(target_arch = "wasm32", feature(stdsimd))]
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
The `core::arch` module is intended to contain various architecture-specific
intrinsics, so use that instead of going directly to LLVM!