### PR TITLE
Fix feature flags for stable Rust testing from #65

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - rustup target add i686-pc-windows-gnu
       script:
         - cd ./wee_alloc
-        - cargo check --release --features "size_classes"
+        - cargo check --release --no-default-features
         - cargo check --release
-        - cargo check --release --features "size_classes" --target i686-pc-windows-gnu
+        - cargo check --release --no-default-features --target i686-pc-windows-gnu
         - cargo check --release                           --target i686-pc-windows-gnu


### PR DESCRIPTION
`size_classes` is enabled by default, so one of the lines had to remain `cargo check --release` but another is supposed to be `cargo check --release --no-default-features` to test without `size_classes` enabled.