### PR TITLE
Increase spin version to 0.5, cease use of removed feature

### DIFF
--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -38,10 +38,9 @@ cfg-if = "0.1.2"
 unreachable = "1.0.0"
 
 [dependencies.spin]
-version = "0.4"
+version = "0.5"
 optional = true
 default-features = false
-features = ["const_fn"]
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies.libc]
 default-features = false


### PR DESCRIPTION
Slightly adjusted follow-up to dependabot suggestion: https://github.com/rustwasm/wee_alloc/pull/75