### PR TITLE
Bump version to 0.4.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Released 2019/02/18.
 
+* Add support for building on stable Rust on Windows and Unix.
 * `wasm32` intrinsics are now invoked using `core::arch` rather than LLVM.
 * Use `SRWLOCK` for windows implementation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.4.3
+
+Released 2019/02/18.
+
+* `wasm32` intrinsics are now invoked using `core::arch` rather than LLVM.
+* Use `SRWLOCK` for windows implementation.
+
 ### 0.4.2
 
 Released 2018/07/16.

--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -11,7 +11,7 @@ license = "MPL-2.0"
 name = "wee_alloc"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/wee_alloc"
-version = "0.4.2"
+version = "0.4.3"
 
 [badges]
 travis-ci = { repository = "rustwasm/wee_alloc" }


### PR DESCRIPTION
After publishing the 0.4.3 version I discovered that the master branch is actually protected : )

Closes #78 