### PR TITLE
wee_alloc for wasm works on stable now!

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+README.md -diff -merge

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ script:
 
 matrix:
   include:
-    - rust: stable
+    - name: "Windows Builds"
+      rust: stable
       before_script:
         - rustup target add i686-pc-windows-gnu
       script:
@@ -32,3 +33,9 @@ matrix:
         - cargo check --release
         - cargo check --release --no-default-features --target i686-pc-windows-gnu
         - cargo check --release                           --target i686-pc-windows-gnu
+    - name: "Stable Wasm Builds"
+      rust: stable
+      before_script:
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - cargo check -p wee_alloc --target wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ and a static array-based backend for OS-independent environments. This enables
 testing `wee_alloc`, and code using `wee_alloc`, without a browser or
 WebAssembly engine.
 
+`wee_alloc` compiles on stable Rust 1.33 and newer.
+
 - [Using `wee_alloc` as the Global Allocator](#using-wee_alloc-as-the-global-allocator)
-- [Does `wee_alloc` require nightly Rust?](#does-wee_alloc-require-nightly-rust)
 - [`cargo` Features](#cargo-features)
 - [Implementation Notes and Constraints](#implementation-notes-and-constraints)
 - [License](#license)
@@ -46,22 +47,6 @@ extern crate wee_alloc;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 ```
-
-### Does `wee_alloc` require nightly Rust?
-
-Sometimes.
-
-Notably, using `wee_alloc` when targeting WebAssembly requires nightly in order
-to get access to the Wasm `grow_memory` instruction (currently exposed as part
-of the `stdsimd` nightly feature).
-
-Targeting Unix and Windows does not require nightly Rust.
-
-The static array-based backend requires nightly Rust in order to have `const`
-spin locks.
-
-Additional nightly-only features can be enabled with the "nightly" cargo
-feature. See below.
 
 ### `cargo` Features
 

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -29,8 +29,9 @@ and a static array-based backend for OS-independent environments. This enables
 testing `wee_alloc`, and code using `wee_alloc`, without a browser or
 WebAssembly engine.
 
+`wee_alloc` compiles on stable Rust 1.33 and newer.
+
 - [Using `wee_alloc` as the Global Allocator](#using-wee_alloc-as-the-global-allocator)
-- [Does `wee_alloc` require nightly Rust?](#does-wee_alloc-require-nightly-rust)
 - [`cargo` Features](#cargo-features)
 - [Implementation Notes and Constraints](#implementation-notes-and-constraints)
 - [License](#license)
@@ -46,22 +47,6 @@ extern crate wee_alloc;
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 # fn main() {}
 ```
-
-## Does `wee_alloc` require nightly Rust?
-
-Sometimes.
-
-Notably, using `wee_alloc` when targeting WebAssembly requires nightly in order
-to get access to the Wasm `grow_memory` instruction (currently exposed as part
-of the `stdsimd` nightly feature).
-
-Targeting Unix and Windows does not require nightly Rust.
-
-The static array-based backend requires nightly Rust in order to have `const`
-spin locks.
-
-Additional nightly-only features can be enabled with the "nightly" cargo
-feature. See below.
 
 ## `cargo` Features
 


### PR DESCRIPTION
Removed the whole "does wee_alloc require nightly rust" section since only using different cargo features might require nightly rust, and that is already documented in the cargo features section.