### PR TITLE
drop unreachable dependency

### DIFF
--- a/wee_alloc/Cargo.toml
+++ b/wee_alloc/Cargo.toml
@@ -35,7 +35,6 @@ use_std_for_test_debugging = []
 [dependencies]
 memory_units = "0.4.0"
 cfg-if = "0.1.2"
-unreachable = "1.0.0"
 
 [dependencies.spin]
 version = "0.5"

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -185,7 +185,6 @@ extern crate core;
 extern crate spin;
 
 extern crate memory_units;
-extern crate unreachable;
 
 #[macro_use]
 mod extra_assert;
@@ -825,10 +824,9 @@ cfg_if! {
     } else {
         #[inline]
         unsafe fn unchecked_unwrap<T>(o: Option<T>) -> T {
-            use unreachable::unreachable;
             match o {
                 Some(t) => t,
-                None => unreachable(),
+                None => core::hint::unreachable_unchecked(),
             }
         }
     }


### PR DESCRIPTION
std::hints::unreachable_unchecked is stable since 1.27.0