### PR TITLE
Ensure that the static array backend's scratch heap is page-aligned

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -20,7 +20,7 @@ time cargo test --release --features "extra_assertions"
 time cargo test --release --features "size_classes"
 time cargo test --release
 
-export WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES=$((1024 * 1024 * 1024))
+export WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES=$((512 * 1024 * 1024))
 
 time cargo test --release --features "static_array_backend extra_assertions size_classes"
 time cargo test --release --features "static_array_backend extra_assertions"

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -502,6 +502,17 @@ fn smoke() {
     }
 }
 
+#[test]
+fn cannot_alloc_max_usize() {
+    let mut a = &wee_alloc::WeeAlloc::INIT;
+    unsafe {
+        let layout = Layout::from_size_align(std::usize::MAX, 1)
+            .expect("should be able to create a `Layout` with size = std::usize::MAX");
+        let result = a.alloc(layout);
+        assert!(result.is_err());
+    }
+}
+
 // This takes too long with our extra assertion checks enabled,
 // and the fixed-sized static array backend is too small.
 #[test]

--- a/wee_alloc/src/imp_static_array.rs
+++ b/wee_alloc/src/imp_static_array.rs
@@ -20,7 +20,7 @@ static mut OFFSET: Mutex<usize> = Mutex::new(0);
 pub(crate) unsafe fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocErr> {
     let bytes: Bytes = pages.into();
     let mut offset = OFFSET.lock();
-    let end = bytes.0 + *offset;
+    let end = bytes.0.checked_add(*offset).ok_or(AllocErr)?;
     if end < SCRATCH_LEN_BYTES {
         let ptr = SCRATCH_HEAP.0[*offset..end].as_mut_ptr() as *mut u8;
         *offset = end;

--- a/wee_alloc/src/imp_static_array.rs
+++ b/wee_alloc/src/imp_static_array.rs
@@ -1,13 +1,20 @@
-use const_init::ConstInit;
 use super::AllocErr;
+use const_init::ConstInit;
 #[cfg(feature = "extra_assertions")]
 use core::cell::Cell;
 use core::ptr::NonNull;
 use memory_units::{Bytes, Pages};
 use spin::Mutex;
 
-const SCRATCH_LEN_BYTES: usize = include!(concat!(env!("OUT_DIR"), "/wee_alloc_static_array_backend_size_bytes.txt"));
-static mut SCRATCH_HEAP: [u8; SCRATCH_LEN_BYTES] = [0; SCRATCH_LEN_BYTES];
+const SCRATCH_LEN_BYTES: usize = include!(concat!(
+    env!("OUT_DIR"),
+    "/wee_alloc_static_array_backend_size_bytes.txt"
+));
+
+#[repr(align(4096))]
+struct ScratchHeap([u8; SCRATCH_LEN_BYTES]);
+
+static mut SCRATCH_HEAP: ScratchHeap = ScratchHeap([0; SCRATCH_LEN_BYTES]);
 static mut OFFSET: Mutex<usize> = Mutex::new(0);
 
 pub(crate) unsafe fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocErr> {
@@ -15,7 +22,7 @@ pub(crate) unsafe fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocErr> 
     let mut offset = OFFSET.lock();
     let end = bytes.0 + *offset;
     if end < SCRATCH_LEN_BYTES {
-        let ptr = SCRATCH_HEAP[*offset..end].as_mut_ptr() as *mut u8;
+        let ptr = SCRATCH_HEAP.0[*offset..end].as_mut_ptr() as *mut u8;
         *offset = end;
         NonNull::new(ptr).ok_or_else(|| AllocErr)
     } else {


### PR DESCRIPTION
Technically, at minimum we only assert that `imp::alloc_pages` returns a block of memory that is word-aligned, but it makes sense to me to keep it "page"-aligned as that is the granularity of allocation in the backend (this might be a system without virtual memory, so "page" is maybe a misnomer).

This should help with #85 

@ZackPierce or @DrGoldfire could you take a look at this?

+cc @nand-nor