### PR TITLE
Cleanup and fix warnings on example

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -20,26 +20,22 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 // raise a `trap` the WebAssembly execution if we panic at runtime.
 #[panic_handler]
 #[no_mangle]
-pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
-    unsafe {
-        ::core::intrinsics::abort();
-    }
+unsafe fn panic(_info: &::core::panic::PanicInfo) -> ! {
+    ::core::intrinsics::abort();
 }
 
 // Need to provide an allocation error handler which just aborts
 // the execution with trap.
 #[alloc_error_handler]
 #[no_mangle]
-pub extern "C" fn oom(_: ::core::alloc::Layout) -> ! {
-    unsafe {
-        ::core::intrinsics::abort();
-    }
+unsafe fn oom(_: ::core::alloc::Layout) -> ! {
+    ::core::intrinsics::abort();
 }
 
 // Needed for non-wasm targets.
 #[lang = "eh_personality"]
 #[no_mangle]
-pub extern "C" fn eh_personality() {}
+extern "C" fn eh_personality() {}
 
 // Now, use the allocator via `alloc` types! ///////////////////////////////////
 


### PR DESCRIPTION
Cleanup of some warnings in example

```rust
$ cargo +nightly build --release --target wasm32-unknown-unknown

   Compiling wee_alloc_example v0.1.0 (/home/sharks/source/wee_alloc/example)
warning: unnecessary `unsafe` block
  --> example/src/lib.rs:24:5
   |
24 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block
   |
   = note: `#[warn(unused_unsafe)]` on by default

warning: unnecessary `unsafe` block
  --> example/src/lib.rs:34:5
   |
34 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block

warning: `extern` fn uses type `core::alloc::Layout`, which is not FFI-safe
  --> example/src/lib.rs:33:26
   |
33 | pub extern "C" fn oom(_: ::core::alloc::Layout) -> ! {
   |                          ^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
   |
   = note: `#[warn(improper_ctypes_definitions)]` on by default
   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
   = note: this struct has unspecified layout

warning: 3 warnings emitted

    Finished release [optimized + debuginfo] target(s) in 0.21s
```