### PR TITLE
Update Allocator trait implementation to compile on nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
   nightly Rust.
 
 - **nightly**: Enable usage of nightly-only Rust features, such as implementing
-  the `Alloc` trait (not to be confused with the stable `GlobalAlloc` trait!)
+  the `Allocator` trait (not to be confused with the stable `GlobalAlloc` trait!)
 
 ### Implementation Notes and Constraints
 

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -21,9 +21,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 #[panic_handler]
 #[no_mangle]
 pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
-    unsafe {
-        ::core::intrinsics::abort();
-    }
+    ::core::intrinsics::abort();
 }
 
 // Need to provide an allocation error handler which just aborts
@@ -31,9 +29,7 @@ pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
 #[alloc_error_handler]
 #[no_mangle]
 pub extern "C" fn oom(_: ::core::alloc::Layout) -> ! {
-    unsafe {
-        ::core::intrinsics::abort();
-    }
+    ::core::intrinsics::abort();
 }
 
 // Needed for non-wasm targets.

--- a/wee_alloc/build.rs
+++ b/wee_alloc/build.rs
@@ -15,10 +15,14 @@ fn create_static_array_backend_size_bytes_file() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR environment variable not provided");
     let dest_path = Path::new(&out_dir).join("wee_alloc_static_array_backend_size_bytes.txt");
     let size: u32 = match env::var(WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES) {
-        Ok(s) => s.parse().expect("Could not interpret WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES as a 32 bit unsigned integer"),
+        Ok(s) => s.parse().expect(
+            "Could not interpret WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES as a 32 bit unsigned integer",
+        ),
         Err(ve) => match ve {
-            VarError::NotPresent => { DEFAULT_STATIC_ARRAY_BACKEND_SIZE_BYTES },
-            VarError::NotUnicode(_) => { panic!("Could not interpret WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES as a string representing a 32 bit unsigned integer")},
+            VarError::NotPresent => DEFAULT_STATIC_ARRAY_BACKEND_SIZE_BYTES,
+            VarError::NotUnicode(_) => {
+                panic!("Could not interpret WEE_ALLOC_STATIC_ARRAY_BACKEND_BYTES as a string representing a 32 bit unsigned integer")
+            }
         },
     };
     let mut f = File::create(&dest_path)

--- a/wee_alloc/src/imp_static_array.rs
+++ b/wee_alloc/src/imp_static_array.rs
@@ -1,4 +1,4 @@
-use super::AllocErr;
+use super::AllocError;
 use const_init::ConstInit;
 #[cfg(feature = "extra_assertions")]
 use core::cell::Cell;
@@ -17,16 +17,16 @@ struct ScratchHeap([u8; SCRATCH_LEN_BYTES]);
 static mut SCRATCH_HEAP: ScratchHeap = ScratchHeap([0; SCRATCH_LEN_BYTES]);
 static mut OFFSET: Mutex<usize> = Mutex::new(0);
 
-pub(crate) unsafe fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocErr> {
+pub(crate) unsafe fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocError> {
     let bytes: Bytes = pages.into();
     let mut offset = OFFSET.lock();
-    let end = bytes.0.checked_add(*offset).ok_or(AllocErr)?;
+    let end = bytes.0.checked_add(*offset).ok_or(AllocError)?;
     if end < SCRATCH_LEN_BYTES {
         let ptr = SCRATCH_HEAP.0[*offset..end].as_mut_ptr() as *mut u8;
         *offset = end;
-        NonNull::new(ptr).ok_or_else(|| AllocErr)
+        NonNull::new(ptr).ok_or_else(|| AllocError)
     } else {
-        Err(AllocErr)
+        Err(AllocError)
     }
 }
 

--- a/wee_alloc/src/imp_unix.rs
+++ b/wee_alloc/src/imp_unix.rs
@@ -1,11 +1,11 @@
-use super::AllocErr;
+use super::AllocError;
 use const_init::ConstInit;
 use core::cell::UnsafeCell;
 use core::ptr;
 use libc;
 use memory_units::{Bytes, Pages};
 
-pub(crate) fn alloc_pages(pages: Pages) -> Result<ptr::NonNull<u8>, AllocErr> {
+pub(crate) fn alloc_pages(pages: Pages) -> Result<ptr::NonNull<u8>, AllocError> {
     unsafe {
         let bytes: Bytes = pages.into();
         let addr = libc::mmap(
@@ -17,9 +17,9 @@ pub(crate) fn alloc_pages(pages: Pages) -> Result<ptr::NonNull<u8>, AllocErr> {
             0,
         );
         if addr == libc::MAP_FAILED {
-            Err(AllocErr)
+            Err(AllocError)
         } else {
-            ptr::NonNull::new(addr as *mut u8).ok_or(AllocErr)
+            ptr::NonNull::new(addr as *mut u8).ok_or(AllocError)
         }
     }
 }

--- a/wee_alloc/src/imp_wasm32.rs
+++ b/wee_alloc/src/imp_wasm32.rs
@@ -1,19 +1,19 @@
-use super::{assert_is_word_aligned, PAGE_SIZE, unchecked_unwrap};
+use super::AllocError;
+use super::{assert_is_word_aligned, unchecked_unwrap, PAGE_SIZE};
 use const_init::ConstInit;
-use super::AllocErr;
 use core::arch::wasm32;
 use core::cell::UnsafeCell;
 use core::ptr::NonNull;
 use memory_units::Pages;
 
-pub(crate) unsafe fn alloc_pages(n: Pages) -> Result<NonNull<u8>, AllocErr> {
+pub(crate) unsafe fn alloc_pages(n: Pages) -> Result<NonNull<u8>, AllocError> {
     let ptr = wasm32::memory_grow(0, n.0);
     if ptr != usize::max_value() {
         let ptr = (ptr * PAGE_SIZE.0) as *mut u8;
         assert_is_word_aligned(ptr as *mut u8);
         Ok(unchecked_unwrap(NonNull::new(ptr)))
     } else {
-        Err(AllocErr)
+        Err(AllocError)
     }
 }
 

--- a/wee_alloc/src/imp_windows.rs
+++ b/wee_alloc/src/imp_windows.rs
@@ -1,5 +1,5 @@
+use super::AllocError;
 use const_init::ConstInit;
-use super::AllocErr;
 use core::cell::UnsafeCell;
 use core::ptr::NonNull;
 use memory_units::{Bytes, Pages};
@@ -7,14 +7,14 @@ use memory_units::{Bytes, Pages};
 use winapi::shared::ntdef::NULL;
 use winapi::um::memoryapi::VirtualAlloc;
 use winapi::um::synchapi::{
-    SRWLOCK, SRWLOCK_INIT, AcquireSRWLockExclusive, ReleaseSRWLockExclusive,
+    AcquireSRWLockExclusive, ReleaseSRWLockExclusive, SRWLOCK, SRWLOCK_INIT,
 };
 use winapi::um::winnt::{MEM_COMMIT, PAGE_READWRITE};
 
-pub(crate) fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocErr> {
+pub(crate) fn alloc_pages(pages: Pages) -> Result<NonNull<u8>, AllocError> {
     let bytes: Bytes = pages.into();
     let ptr = unsafe { VirtualAlloc(NULL, bytes.0, MEM_COMMIT, PAGE_READWRITE) };
-    NonNull::new(ptr as *mut u8).ok_or(AllocErr)
+    NonNull::new(ptr as *mut u8).ok_or(AllocError)
 }
 
 // Align to the cache line size on an i7 to avoid false sharing.

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -65,7 +65,7 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
   nightly Rust.
 
 - **nightly**: Enable usage of nightly-only Rust features, such as implementing
-  the `Alloc` trait (not to be confused with the stable `GlobalAlloc` trait!)
+  the `Allocator` trait (not to be confused with the stable `GlobalAlloc` trait!)
 
 ## Implementation Notes and Constraints
 

--- a/wee_alloc/src/lib.rs
+++ b/wee_alloc/src/lib.rs
@@ -218,9 +218,9 @@ mod size_classes;
 
 cfg_if! {
     if #[cfg(feature = "nightly")] {
-        use core::alloc::{Alloc, AllocErr};
+        use core::alloc::{Allocator, AllocError};
     } else {
-        pub(crate) struct AllocErr;
+        pub(crate) struct AllocError;
     }
 }
 
@@ -759,7 +759,7 @@ trait AllocPolicy<'a> {
         &self,
         size: Words,
         align: Bytes,
-    ) -> Result<*const FreeCell<'a>, AllocErr>;
+    ) -> Result<*const FreeCell<'a>, AllocError>;
 
     fn min_cell_size(&self, alloc_size: Words) -> Words;
 
@@ -785,7 +785,7 @@ impl<'a> AllocPolicy<'a> for LargeAllocPolicy {
         &self,
         size: Words,
         align: Bytes,
-    ) -> Result<*const FreeCell<'a>, AllocErr> {
+    ) -> Result<*const FreeCell<'a>, AllocError> {
         // To assure that an allocation will always succeed after refilling the
         // free list with this new cell, make sure that we allocate enough to
         // fulfill the requested alignment, and still have the minimum cell size
@@ -846,7 +846,7 @@ unsafe fn walk_free_list<'a, F, T>(
     head: &Cell<*const FreeCell<'a>>,
     policy: &dyn AllocPolicy<'a>,
     mut f: F,
-) -> Result<T, AllocErr>
+) -> Result<T, AllocError>
 where
     F: FnMut(&Cell<*const FreeCell<'a>>, &FreeCell<'a>) -> Option<T>,
 {
@@ -859,7 +859,7 @@ where
         assert_local_cell_invariants(&(*current_free).header);
 
         if current_free.is_null() {
-            return Err(AllocErr);
+            return Err(AllocError);
         }
 
         let current_free = Cell::new(current_free);
@@ -914,7 +914,7 @@ unsafe fn alloc_first_fit<'a>(
     align: Bytes,
     head: &Cell<*const FreeCell<'a>>,
     policy: &dyn AllocPolicy<'a>,
-) -> Result<NonNull<u8>, AllocErr> {
+) -> Result<NonNull<u8>, AllocError> {
     extra_assert!(size.0 > 0);
 
     walk_free_list(head, policy, |previous, current| {
@@ -934,7 +934,7 @@ unsafe fn alloc_with_refill<'a, 'b>(
     align: Bytes,
     head: &'b Cell<*const FreeCell<'a>>,
     policy: &dyn AllocPolicy<'a>,
-) -> Result<NonNull<u8>, AllocErr> {
+) -> Result<NonNull<u8>, AllocError> {
     if let Ok(result) = alloc_first_fit(size, align, head, policy) {
         return Ok(result);
     }
@@ -1027,7 +1027,7 @@ impl<'a> WeeAlloc<'a> {
         })
     }
 
-    unsafe fn alloc_impl(&self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+    unsafe fn alloc_impl(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         let size = Bytes(layout.size());
         let align = if layout.align() == 0 {
             Bytes(1)
@@ -1042,7 +1042,7 @@ impl<'a> WeeAlloc<'a> {
             return Ok(NonNull::new_unchecked(align.0 as *mut u8));
         }
 
-        let word_size: Words = checked_round_up_to(size).ok_or(AllocErr)?;
+        let word_size: Words = checked_round_up_to(size).ok_or(AllocError)?;
 
         self.with_free_list_and_policy_for_size(word_size, align, |head, policy| {
             assert_is_valid_free_list(head.get(), policy);
@@ -1142,15 +1142,15 @@ impl<'a> WeeAlloc<'a> {
 }
 
 #[cfg(feature = "nightly")]
-unsafe impl<'a, 'b> Alloc for &'b WeeAlloc<'a>
+unsafe impl<'a, 'b> Allocator for &'b WeeAlloc<'a>
 where
     'a: 'b,
 {
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         self.alloc_impl(layout)
     }
 
-    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         self.dealloc_impl(ptr, layout)
     }
 }
@@ -1159,7 +1159,7 @@ unsafe impl GlobalAlloc for WeeAlloc<'static> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         match self.alloc_impl(layout) {
             Ok(ptr) => ptr.as_ptr(),
-            Err(AllocErr) => ptr::null_mut(),
+            Err(AllocError) => ptr::null_mut(),
         }
     }
 

--- a/wee_alloc/src/size_classes.rs
+++ b/wee_alloc/src/size_classes.rs
@@ -41,7 +41,6 @@ where
         size: Words,
         align: Bytes,
     ) -> Result<*const FreeCell<'a>, AllocError> {
-        extra_assert!(align.0 > 0);
         extra_assert!(align.0.is_power_of_two());
         extra_assert!(align <= size_of::<usize>());
 
@@ -68,12 +67,12 @@ where
         let new_cell_size: Bytes = new_cell_size.into();
 
         let free_cell = FreeCell::from_uninitialized(
-            new_cell,
+            new_cell.as_non_null_ptr(),
             new_cell_size - size_of::<CellHeader>(),
             None,
             self as &dyn AllocPolicy,
         );
-        let next_cell = (new_cell.as_ptr() as *const u8).offset(new_cell_size.0 as isize);
+        let next_cell = (new_cell.as_mut_ptr() as *const u8).offset(new_cell_size.0 as isize);
         (*free_cell)
             .header
             .neighbors

--- a/wee_alloc/src/size_classes.rs
+++ b/wee_alloc/src/size_classes.rs
@@ -1,4 +1,7 @@
-use super::{alloc_with_refill, AllocError, AllocPolicy, CellHeader, FreeCell, LargeAllocPolicy};
+use super::{
+    alloc_with_refill, nonnull_slice_as_mut_ptr, nonnull_slice_as_non_null_ptr, AllocError,
+    AllocPolicy, CellHeader, FreeCell, LargeAllocPolicy,
+};
 use const_init::ConstInit;
 use core::cell::Cell;
 use core::cmp;
@@ -67,12 +70,13 @@ where
         let new_cell_size: Bytes = new_cell_size.into();
 
         let free_cell = FreeCell::from_uninitialized(
-            new_cell.as_non_null_ptr(),
+            nonnull_slice_as_non_null_ptr(new_cell),
             new_cell_size - size_of::<CellHeader>(),
             None,
             self as &dyn AllocPolicy,
         );
-        let next_cell = (new_cell.as_mut_ptr() as *const u8).offset(new_cell_size.0 as isize);
+        let next_cell =
+            (nonnull_slice_as_mut_ptr(new_cell) as *const u8).offset(new_cell_size.0 as isize);
         (*free_cell)
             .header
             .neighbors

--- a/wee_alloc/src/size_classes.rs
+++ b/wee_alloc/src/size_classes.rs
@@ -1,4 +1,4 @@
-use super::{alloc_with_refill, AllocErr, AllocPolicy, CellHeader, FreeCell, LargeAllocPolicy};
+use super::{alloc_with_refill, AllocError, AllocPolicy, CellHeader, FreeCell, LargeAllocPolicy};
 use const_init::ConstInit;
 use core::cell::Cell;
 use core::cmp;
@@ -40,7 +40,7 @@ where
         &self,
         size: Words,
         align: Bytes,
-    ) -> Result<*const FreeCell<'a>, AllocErr> {
+    ) -> Result<*const FreeCell<'a>, AllocError> {
         extra_assert!(align.0 > 0);
         extra_assert!(align.0.is_power_of_two());
         extra_assert!(align <= size_of::<usize>());


### PR DESCRIPTION
Fixes issue #94 

The wee_alloc build has been broken for a bit because the Rust `Allocator` (previously called  `Alloc`) trait has changed interfaces. This PR updates the wee_alloc implementation to compile and run on nightly. 

There are probably some more cleanup possible and different testing possibilities with the new interface, but I tried to make the minimal changes necessary to fix the build and unblock other contributions.

Some functions and methods that are still experimental I implemented as helper-functions to avoid requiring nightly for the library, but left TODO comments to update once they stabilize.

Haven't made a ton of Rust contributions so let me know if I missed anything here!